### PR TITLE
Feature/test printer connection

### DIFF
--- a/client-vue/src/App.vue
+++ b/client-vue/src/App.vue
@@ -56,16 +56,22 @@ export default class App extends Vue {
   }
 
   async onSseMessage(message: PrinterSseMessage) {
-    await this.$store.dispatch(ACTIONS.savePrinters, message.printers);
+    if (message.printers) {
+      await this.$store.dispatch(ACTIONS.savePrinters, message);
+    }
 
-    // Emit the global update
-    this.$bus.emit(sseMessageGlobal, message);
+    if (message.testPrinter) {
+      // Emit the global update
+      this.$bus.emit(sseMessageGlobal, message);
 
-    // Emit a specific testing session update
-    const testPrinter = message.testPrinter;
-    if (!testPrinter?.correlationToken) return;
+      // Emit a specific testing session update
+      const testPrinter = message.testPrinter;
+      if (!testPrinter?.correlationToken) return;
 
-    this.$bus.emit(sseTestPrinterUpdate(testPrinter.correlationToken), testPrinter);
+      console.log(testPrinter);
+
+      this.$bus.emit(sseTestPrinterUpdate(testPrinter.correlationToken), testPrinter);
+    }
   }
 
   beforeDestroy() {

--- a/client-vue/src/App.vue
+++ b/client-vue/src/App.vue
@@ -58,14 +58,14 @@ export default class App extends Vue {
   async onSseMessage(message: PrinterSseMessage) {
     await this.$store.dispatch(ACTIONS.savePrinters, message.printers);
 
-    message.testPrinters.forEach((tp) => {
-      if (!tp.correlationToken) return;
-
-      const eventName = sseTestPrinterUpdate(tp.correlationToken);
-      this.$bus.emit(eventName, tp);
-    });
-
+    // Emit the global update
     this.$bus.emit(sseMessageGlobal, message);
+
+    // Emit a specific testing session update
+    const testPrinter = message.testPrinter;
+    if (!testPrinter?.correlationToken) return;
+
+    this.$bus.emit(sseTestPrinterUpdate(testPrinter.correlationToken), testPrinter);
   }
 
   beforeDestroy() {

--- a/client-vue/src/App.vue
+++ b/client-vue/src/App.vue
@@ -57,7 +57,7 @@ export default class App extends Vue {
 
   async onSseMessage(message: PrinterSseMessage) {
     if (message.printers) {
-      await this.$store.dispatch(ACTIONS.savePrinters, message);
+      await this.$store.dispatch(ACTIONS.savePrinters, message.printers);
     }
 
     if (message.testPrinter) {

--- a/client-vue/src/App.vue
+++ b/client-vue/src/App.vue
@@ -65,12 +65,13 @@ export default class App extends Vue {
       this.$bus.emit(sseMessageGlobal, message);
 
       // Emit a specific testing session update
-      const testPrinter = message.testPrinter;
+      const { testPrinter, testProgress } = message;
       if (!testPrinter?.correlationToken) return;
 
-      console.log(testPrinter);
-
-      this.$bus.emit(sseTestPrinterUpdate(testPrinter.correlationToken), testPrinter);
+      this.$bus.emit(sseTestPrinterUpdate(testPrinter.correlationToken), {
+        testPrinter,
+        testProgress
+      });
     }
   }
 

--- a/client-vue/src/backend/printers.service.ts
+++ b/client-vue/src/backend/printers.service.ts
@@ -15,6 +15,12 @@ export class PrintersService extends BaseService {
     return await this.postApi(path, printer);
   }
 
+  static async testConnection(printer: Printer) {
+    const path = ServerApi.printerTestConnectionRoute;
+
+    return await this.postApi(path, printer);
+  }
+
   static async toggleEnabled(printerId: string, enabled: boolean) {
     const path = ServerApi.printerEnabledRoute(printerId);
 

--- a/client-vue/src/backend/printers.service.ts
+++ b/client-vue/src/backend/printers.service.ts
@@ -15,6 +15,12 @@ export class PrintersService extends BaseService {
     return await this.postApi(path, printer);
   }
 
+  static async deletePrinter(printerId: string) {
+    const path = ServerApi.getPrinterRoute(printerId);
+
+    return await this.deleteApi(path);
+  }
+
   static async testConnection(printer: Printer) {
     const path = ServerApi.printerTestConnectionRoute;
 

--- a/client-vue/src/backend/server.api.ts
+++ b/client-vue/src/backend/server.api.ts
@@ -2,6 +2,7 @@ export class ServerApi {
   static base = "api";
   static amIAliveRoute = ServerApi.base + "/amialive";
   static printerRoute = ServerApi.base + "/printer";
+  static printerTestConnectionRoute = ServerApi.printerRoute + "/test-connection";
   static printerGroupsRoute = ServerApi.base + "/printer-groups";
   static printerFilesRoute = ServerApi.base + "/printer-files";
   static printerNetworkRoute = ServerApi.base + "/printer-network";

--- a/client-vue/src/backend/server.api.ts
+++ b/client-vue/src/backend/server.api.ts
@@ -32,5 +32,6 @@ export class ServerApi {
   static testAlertScriptRoute = ServerApi.alertRoute + "/test-alert-script";
   static roomDataRoute = ServerApi.base + "/room-data";
 
-  static printerEnabledRoute = (id: string) => ServerApi.printerRoute + `/${id}/enabled`;
+  static getPrinterRoute = (id: string) => `${ServerApi.printerRoute}/${id}`;
+  static printerEnabledRoute = (id: string) => `${ServerApi.getPrinterRoute(id)}/enabled`;
 }

--- a/client-vue/src/components/Dialogs/CreatePrinterDialog.vue
+++ b/client-vue/src/components/Dialogs/CreatePrinterDialog.vue
@@ -146,7 +146,7 @@
             <em class="red--text">* indicates required field</em>
             <v-spacer></v-spacer>
             <v-btn text @click="closeDialog()"> Close</v-btn>
-            <v-btn color="warning" text @click="testPrinter()">Test</v-btn>
+            <v-btn color="warning" text @click="testPrinter()">Test connection</v-btn>
             <v-btn :disabled="invalid" color="blue darken-1" text @click="submit()">Save</v-btn>
           </v-card-actions>
         </v-card>
@@ -160,7 +160,11 @@
 import Vue from "vue";
 import { Component, Prop } from "vue-property-decorator";
 import { ValidationObserver, ValidationProvider } from "vee-validate";
-import { CreatePrinter, defaultCreatePrinter, PreCreatePrinter } from "@/models/printers/crud/create-printer.model";
+import {
+  CreatePrinter,
+  defaultCreatePrinter,
+  PreCreatePrinter
+} from "@/models/printers/crud/create-printer.model";
 import { ACTIONS } from "@/store/printers/printers.actions";
 import { apiKeyLength } from "@/constants/validation.constants";
 import { Action } from "vuex-class";
@@ -202,8 +206,14 @@ export default class CreatePrinterDialog extends Vue {
     await this.loadPrinterGroups();
   }
 
-  testPrinter() {
-    // console.log(this.$refs.printerCreateForm.validate());
+  async testPrinter() {
+    const result = await this.$refs.validationObserver.validate();
+
+    if (!result) return;
+
+    const newPrinterData = this.transformFormData();
+
+    await this.$store.dispatch(ACTIONS.createTestPrinter, newPrinterData);
   }
 
   async submit() {
@@ -213,7 +223,6 @@ export default class CreatePrinterDialog extends Vue {
 
     const newPrinterData = this.transformFormData();
 
-    console.log(newPrinterData);
     await this.$store.dispatch(ACTIONS.createPrinter, newPrinterData);
   }
 

--- a/client-vue/src/components/Dialogs/CreatePrinterDialog.vue
+++ b/client-vue/src/components/Dialogs/CreatePrinterDialog.vue
@@ -224,7 +224,7 @@ export default class CreatePrinterDialog extends Vue {
   }
 
   async onTestPrinterUpdate(payload: Printer) {
-    console.log(payload);
+    console.log("received update", payload.correlationToken, payload.hostState);
   }
 
   async submit() {

--- a/client-vue/src/components/Dialogs/CreatePrinterDialog.vue
+++ b/client-vue/src/components/Dialogs/CreatePrinterDialog.vue
@@ -272,6 +272,8 @@ export default class CreatePrinterDialog extends Vue {
     if (!validationResult) return;
 
     this.showChecksPanel = true;
+    this.testProgress = undefined;
+    
     const testPrinter = this.transformFormData();
 
     const result: Printer = await this.$store.dispatch(ACTIONS.createTestPrinter, testPrinter);

--- a/client-vue/src/components/Dialogs/CreatePrinterDialog.vue
+++ b/client-vue/src/components/Dialogs/CreatePrinterDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <v-row justify="center">
-    <v-dialog v-model="mutableShow" max-width="600px" persistent>
+    <v-dialog v-model="mutableShow" :max-width="showChecksPanel ? '700px' : '600px'" persistent>
       <!--      <template v-slot:activator="{ on, attrs }">-->
       <!--        <v-btn v-bind="attrs" v-on="on" color="primary" dark> Open Dialog</v-btn>-->
       <!--      </template>-->
@@ -10,144 +10,194 @@
             <span class="text-h5">New Printer</span>
           </v-card-title>
           <v-card-text>
-            <v-container>
-              <v-row>
-                <v-col cols="12" md="6">
-                  <validation-provider v-slot="{ errors }" name="Name" rules="required|max:10">
-                    <v-text-field
-                      v-model="formData.printerName"
-                      :error-messages="errors"
-                      label="Printer name*"
-                      required
-                    />
-                  </validation-provider>
-                </v-col>
-                <v-col cols="12" md="6">
-                  <validation-provider v-slot="{ errors }" name="Groups">
-                    <v-select
-                      v-model="formData.groups"
-                      :error-messages="errors"
-                      :items="['asd', '123']"
-                      label="Group(s)"
-                      multiple
-                      required
-                    ></v-select>
-                  </validation-provider>
-                </v-col>
-                <v-col cols="12" md="6">
-                  <validation-provider
-                    v-slot="{ errors }"
-                    name="Printer IP or HostName"
-                    rules="required|ip_or_fqdn"
-                  >
-                    <v-text-field
-                      v-model="formData.printerHostName"
-                      :error-messages="errors"
-                      hint="Examples: 'my.printer.com', 'localhost' or '192.x.x.x'"
-                      label="IP/Host*"
-                    ></v-text-field>
-                  </validation-provider>
-                </v-col>
-                <v-col cols="12" md="6">
-                  <validation-provider
-                    v-slot="{ errors }"
-                    name="Host Port"
-                    rules="required|integer|max:65535"
-                  >
-                    <v-text-field
-                      v-model="formData.printerHostPort"
-                      :error-messages="errors"
-                      hint="Examples: '80', '443' or '5050'"
-                      label="Host Port*"
-                    ></v-text-field>
-                  </validation-provider>
-                </v-col>
-                <v-col cols="12" md="6">
-                  <validation-provider v-slot="{ errors }" name="Enabled">
-                    <v-checkbox
-                      v-model="formData.enabled"
-                      :error-messages="errors"
-                      hint="Disabling makes the printer passive"
-                      label="Enabled*"
-                      persistent-hint
-                      required
-                    ></v-checkbox>
-                  </validation-provider>
-                </v-col>
-                <v-col cols="12" md="12">
-                  <validation-provider v-slot="{ errors }" :rules="apiKeyRules" name="ApiKey">
-                    <v-text-field
-                      v-model="formData.apiKey"
-                      :counter="apiKeyRules.length"
-                      :error-messages="errors"
-                      hint="User or Application Key only (Global API key fails)"
-                      label="API Key*"
-                      persistent-hint
-                      required
-                    ></v-text-field>
-                  </validation-provider>
-                </v-col>
-              </v-row>
+            <v-row>
+              <v-col :cols="showChecksPanel ? 8 : 12">
+                <v-container>
+                  <v-row>
+                    <v-col cols="12" md="6">
+                      <validation-provider v-slot="{ errors }" name="Name" rules="required|max:10">
+                        <v-text-field
+                          v-model="formData.printerName"
+                          :error-messages="errors"
+                          label="Printer name*"
+                          required
+                        />
+                      </validation-provider>
+                    </v-col>
+                    <v-col cols="12" md="6">
+                      <validation-provider v-slot="{ errors }" name="Groups">
+                        <v-select
+                          v-model="formData.groups"
+                          :error-messages="errors"
+                          :items="['asd', '123']"
+                          label="Group(s)"
+                          multiple
+                          required
+                        ></v-select>
+                      </validation-provider>
+                    </v-col>
+                    <v-col cols="12" md="6">
+                      <validation-provider
+                        v-slot="{ errors }"
+                        name="Printer IP or HostName"
+                        rules="required|ip_or_fqdn"
+                      >
+                        <v-text-field
+                          v-model="formData.printerHostName"
+                          :error-messages="errors"
+                          hint="Examples: 'my.printer.com', 'localhost' or '192.x.x.x'"
+                          label="IP/Host*"
+                        ></v-text-field>
+                      </validation-provider>
+                    </v-col>
+                    <v-col cols="12" md="6">
+                      <validation-provider
+                        v-slot="{ errors }"
+                        name="Host Port"
+                        rules="required|integer|max:65535"
+                      >
+                        <v-text-field
+                          v-model="formData.printerHostPort"
+                          :error-messages="errors"
+                          hint="Examples: '80', '443' or '5050'"
+                          label="Host Port*"
+                        ></v-text-field>
+                      </validation-provider>
+                    </v-col>
+                    <v-col cols="12" md="6">
+                      <validation-provider v-slot="{ errors }" name="Enabled">
+                        <v-checkbox
+                          v-model="formData.enabled"
+                          :error-messages="errors"
+                          hint="Disabling makes the printer passive"
+                          label="Enabled*"
+                          persistent-hint
+                          required
+                        ></v-checkbox>
+                      </validation-provider>
+                    </v-col>
+                    <v-col cols="12" md="12">
+                      <validation-provider v-slot="{ errors }" :rules="apiKeyRules" name="ApiKey">
+                        <v-text-field
+                          v-model="formData.apiKey"
+                          :counter="apiKeyRules.length"
+                          :error-messages="errors"
+                          hint="User or Application Key only (Global API key fails)"
+                          label="API Key*"
+                          persistent-hint
+                          required
+                        ></v-text-field>
+                      </validation-provider>
+                    </v-col>
+                  </v-row>
 
-              <v-expansion-panels>
-                <v-expansion-panel>
-                  <v-expansion-panel-header>Advanced settings</v-expansion-panel-header>
-                  <v-expansion-panel-content>
-                    <validation-provider v-slot="{ errors }" name="Display">
-                      <v-checkbox
-                        v-model="formData.display"
-                        :error-messages="errors"
-                        label="Display*"
-                        required
-                      ></v-checkbox>
-                    </validation-provider>
-                    <v-col cols="12" md="6">
-                      <validation-provider v-slot="{ errors }" name="StepSize">
-                        <v-select
-                          v-model="formData.stepSize"
-                          :error-messages="errors"
-                          :items="[0.1, 1, 10, 100]"
-                          label="Step-size for manual control"
-                          required
-                          value="http"
-                        ></v-select>
-                      </validation-provider>
-                    </v-col>
-                    <v-col cols="12" md="6">
-                      <validation-provider v-slot="{ errors }" name="PrinterHostPrefix">
-                        <v-select
-                          v-model="formData.printerHostPrefix"
-                          :error-messages="errors"
-                          :items="['http', 'https']"
-                          label="Insecure/Secure HTTP"
-                          required
-                          value="http"
-                        ></v-select>
-                      </validation-provider>
-                    </v-col>
-                    <v-col cols="12" md="6">
-                      <validation-provider v-slot="{ errors }" name="WebsocketPrefix">
-                        <v-select
-                          v-model="formData.websocketPrefix"
-                          :error-messages="errors"
-                          :items="['ws', 'wss']"
-                          label="Insecure/Secure Websocket"
-                          required
-                          value="ws"
-                        ></v-select>
-                      </validation-provider>
-                    </v-col>
-                  </v-expansion-panel-content>
-                </v-expansion-panel>
-              </v-expansion-panels>
-            </v-container>
+                  <v-expansion-panels>
+                    <v-expansion-panel>
+                      <v-expansion-panel-header>Advanced settings</v-expansion-panel-header>
+                      <v-expansion-panel-content>
+                        <validation-provider v-slot="{ errors }" name="Display">
+                          <v-checkbox
+                            v-model="formData.display"
+                            :error-messages="errors"
+                            label="Display*"
+                            required
+                          ></v-checkbox>
+                        </validation-provider>
+                        <v-col cols="12" md="6">
+                          <validation-provider v-slot="{ errors }" name="StepSize">
+                            <v-select
+                              v-model="formData.stepSize"
+                              :error-messages="errors"
+                              :items="[0.1, 1, 10, 100]"
+                              label="Step-size for manual control"
+                              required
+                              value="http"
+                            ></v-select>
+                          </validation-provider>
+                        </v-col>
+                        <v-col cols="12" md="6">
+                          <validation-provider v-slot="{ errors }" name="PrinterHostPrefix">
+                            <v-select
+                              v-model="formData.printerHostPrefix"
+                              :error-messages="errors"
+                              :items="['http', 'https']"
+                              label="Insecure/Secure HTTP"
+                              required
+                              value="http"
+                            ></v-select>
+                          </validation-provider>
+                        </v-col>
+                        <v-col cols="12" md="6">
+                          <validation-provider v-slot="{ errors }" name="WebsocketPrefix">
+                            <v-select
+                              v-model="formData.websocketPrefix"
+                              :error-messages="errors"
+                              :items="['ws', 'wss']"
+                              label="Insecure/Secure Websocket"
+                              required
+                              value="ws"
+                            ></v-select>
+                          </validation-provider>
+                        </v-col>
+                      </v-expansion-panel-content>
+                    </v-expansion-panel>
+                  </v-expansion-panels>
+                </v-container>
+              </v-col>
+              <v-col v-if="showChecksPanel" cols="4">
+                <strong>Checks:</strong>
+                <v-alert
+                  v-if="testProgress && isSet(testProgress.connected)"
+                  :type="testProgress.connected ? 'success' : 'error'"
+                  dense
+                  text
+                >
+                  <small>Connected</small>
+                </v-alert>
+                <v-alert
+                  v-if="testProgress && isSet(testProgress.apiOk)"
+                  :type="testProgress.apiOk ? 'success' : 'error'"
+                  dense
+                  text
+                >
+                  <small>API ok</small>
+                </v-alert>
+                <v-alert
+                  v-if="testProgress && isSet(testProgress.apiKeyNotGlobal)"
+                  :type="testProgress.apiKeyNotGlobal ? 'success' : 'error'"
+                  dense
+                  text
+                >
+                  <small>Key not Global API Key</small>
+                </v-alert>
+                <v-alert
+                  v-if="testProgress && isSet(testProgress.apiKeyOk)"
+                  :type="testProgress.apiKeyOk ? 'success' : 'error'"
+                  dense
+                  text
+                >
+                  <small>Key accepted</small>
+                </v-alert>
+                <v-alert
+                  v-if="testProgress && isSet(testProgress.websocketBound)"
+                  :type="testProgress.websocketBound ? 'success' : 'error'"
+                  dense
+                  text
+                >
+                  <small>WebSocket bound</small>
+                </v-alert>
+
+                <v-btn @click="showChecksPanel = false">Hide checks</v-btn>
+              </v-col>
+            </v-row>
           </v-card-text>
           <v-card-actions>
             <em class="red--text">* indicates required field</em>
             <v-spacer></v-spacer>
-            <v-btn text @click="closeDialog()"> Close</v-btn>
-            <v-btn :disabled="invalid" color="warning" text @click="testPrinter()"
-              >Test connection
+            <v-btn text @click="closeDialog()">Close</v-btn>
+<!--            <v-btn text @click="fillTemplate()">Template</v-btn>-->
+            <v-btn :disabled="invalid" color="warning" text @click="testPrinter()">
+              Test connection
             </v-btn>
             <v-btn :disabled="invalid" color="blue darken-1" text @click="submit()">Save</v-btn>
           </v-card-actions>
@@ -169,23 +219,29 @@ import { Action } from "vuex-class";
 import { PrinterGroup } from "@/models/printers/printer-group.model";
 import { Printer } from "@/models/printers/printer.model";
 import { sseTestPrinterUpdate } from "@/event-bus/sse.events";
+import { PrinterSseMessage, TestProgressDetails } from "@/models/sse-messages/printer-sse-message.model";
 
 @Component({
   components: {
     ValidationProvider,
     ValidationObserver
-  }
+  },
+  data: () => ({
+    testProgress: undefined
+  })
 })
 export default class CreatePrinterDialog extends Vue {
   @Prop(Boolean) show: boolean;
   @Action loadPrinterGroups: () => Promise<PrinterGroup[]>;
 
+  apiKeyRules = { required: true, length: apiKeyLength };
   formData: PreCreatePrinter = { ...defaultCreatePrinter };
   $refs!: {
     validationObserver: InstanceType<typeof ValidationObserver>;
   };
 
-  apiKeyRules = { required: true, length: apiKeyLength };
+  showChecksPanel = false;
+  testProgress?: TestProgressDetails = undefined;
 
   get mutableShow() {
     // https://forum.vuejs.org/t/update-data-when-prop-changes-data-derived-from-prop/1517/27
@@ -194,6 +250,10 @@ export default class CreatePrinterDialog extends Vue {
 
   set mutableShow(newValue: boolean) {
     this.$emit("update:show", newValue);
+  }
+
+  isSet(value: boolean) {
+    return value === false || value === true;
   }
 
   async created() {
@@ -211,6 +271,7 @@ export default class CreatePrinterDialog extends Vue {
 
     if (!validationResult) return;
 
+    this.showChecksPanel = true;
     const testPrinter = this.transformFormData();
 
     const result: Printer = await this.$store.dispatch(ACTIONS.createTestPrinter, testPrinter);
@@ -219,9 +280,18 @@ export default class CreatePrinterDialog extends Vue {
     this.$bus.on(sseTestPrinterUpdate(result.correlationToken), this.onTestPrinterUpdate);
   }
 
-  async onTestPrinterUpdate(payload: Printer) {
-    console.log("received update", payload.testProgress);
+  async onTestPrinterUpdate(payload: PrinterSseMessage) {
+    this.testProgress = payload.testProgress;
   }
+
+  // Might be nice for future or for duplication of printers
+  // fillTemplate() {
+  //   this.formData = {
+  //     ...defaultCreatePrinter,
+  //     printerHostPort: 80,
+  //     printerName: "template"
+  //   };
+  // }
 
   async submit() {
     const result = await this.$refs.validationObserver.validate();
@@ -242,8 +312,8 @@ export default class CreatePrinterDialog extends Vue {
     let modifiedData: any = { ...this.formData };
 
     const { printerHostPrefix, websocketPrefix, printerHostName, printerHostPort } = this.formData;
-    const printerURL = new URL(`${printerHostPrefix}://${printerHostName}:${printerHostPort}`);
-    const webSocketURL = new URL(`${websocketPrefix}://${printerHostName}:${printerHostPort}`);
+    const printerURL = new URL(`${ printerHostPrefix }://${ printerHostName }:${ printerHostPort }`);
+    const webSocketURL = new URL(`${ websocketPrefix }://${ printerHostName }:${ printerHostPort }`);
 
     delete modifiedData.printerHostName;
     delete modifiedData.printerHostPrefix;

--- a/client-vue/src/components/Dialogs/CreatePrinterDialog.vue
+++ b/client-vue/src/components/Dialogs/CreatePrinterDialog.vue
@@ -162,11 +162,7 @@
 import Vue from "vue";
 import { Component, Prop } from "vue-property-decorator";
 import { ValidationObserver, ValidationProvider } from "vee-validate";
-import {
-  CreatePrinter,
-  defaultCreatePrinter,
-  PreCreatePrinter
-} from "@/models/printers/crud/create-printer.model";
+import { CreatePrinter, defaultCreatePrinter, PreCreatePrinter } from "@/models/printers/crud/create-printer.model";
 import { ACTIONS } from "@/store/printers/printers.actions";
 import { apiKeyLength } from "@/constants/validation.constants";
 import { Action } from "vuex-class";
@@ -224,7 +220,7 @@ export default class CreatePrinterDialog extends Vue {
   }
 
   async onTestPrinterUpdate(payload: Printer) {
-    console.log("received update", payload.correlationToken, payload.hostState);
+    console.log("received update", payload.testProgress);
   }
 
   async submit() {

--- a/client-vue/src/components/Map.vue
+++ b/client-vue/src/components/Map.vue
@@ -25,8 +25,9 @@ export default class Map extends Vue {
     this.showDialog = true;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   onChangeShowDialog(event: any) {
-    console.debug("Dialog closed", event);
+    // Placeholder
   }
 }
 </script>

--- a/client-vue/src/components/NavigationDrawer.vue
+++ b/client-vue/src/components/NavigationDrawer.vue
@@ -43,7 +43,7 @@ export default {
         ["printer", "Printers", "/printers"],
         ["settings", "Settings", "/settings"],
         ["history", "Scheduling", "/scheduling"],
-        ["contact_support", "About", "/about"],
+        ["contact_support", "About", "/about"]
       ]
     };
   },

--- a/client-vue/src/components/PrinterDetails.vue
+++ b/client-vue/src/components/PrinterDetails.vue
@@ -1,10 +1,11 @@
 <template>
-  <div v-if="printer">
+  <v-container v-if="printer">
+    <v-btn @click="deletePrinter()">Delete printer</v-btn>
     Name: {{ printer.printerName }} <br />
     URL: {{ printer.printerURL }}
 
     <FileList :file-list="printer.fileList" :printer-id="printerId" />
-  </div>
+  </v-container>
 </template>
 
 <script lang="ts">
@@ -13,6 +14,7 @@ import Vue from "vue";
 import FileList from "@/components/FileList.vue";
 import { Prop } from "vue-property-decorator";
 import { Printer } from "@/models/printers/printer.model";
+import { ACTIONS } from "@/store/printers/printers.actions";
 
 @Component({
   components: { FileList }
@@ -22,6 +24,10 @@ export default class PrinterDetails extends Vue {
 
   get printerId() {
     return this.printer.id;
+  }
+
+  async deletePrinter() {
+    await this.$store.dispatch(ACTIONS.deletePrinter, this.printerId);
   }
 }
 </script>

--- a/client-vue/src/event-bus/sse.events.ts
+++ b/client-vue/src/event-bus/sse.events.ts
@@ -1,1 +1,3 @@
-export const sseMessageEventGlobal = "sse-message-global";
+export const sseMessageGlobal = "sse-message-global";
+export const sseTestPrinterUpdate = (correlationToken: string) =>
+  `sse-message-test-printer-${correlationToken}`;

--- a/client-vue/src/models/printers/printer.model.ts
+++ b/client-vue/src/models/printers/printer.model.ts
@@ -7,6 +7,7 @@ import { PrinterProfile } from "@/models/printers/printer-profile.model";
 
 export interface Printer {
   id: string;
+  correlationToken?: string;
   printerState: VisualState;
   hostState: VisualState;
   webSocketState: WebsocketState;

--- a/client-vue/src/models/sse-messages/printer-sse-message.model.ts
+++ b/client-vue/src/models/sse-messages/printer-sse-message.model.ts
@@ -1,4 +1,7 @@
 import { Printer } from "@/models/printers/printer.model";
 
 // Extensibility options for future use
-export type PrinterSseMessage = Printer[];
+export interface PrinterSseMessage {
+  printers: Printer[];
+  testPrinters: Printer[];
+};

--- a/client-vue/src/models/sse-messages/printer-sse-message.model.ts
+++ b/client-vue/src/models/sse-messages/printer-sse-message.model.ts
@@ -1,6 +1,15 @@
 import { Printer } from "@/models/printers/printer.model";
 
+export interface TestProgressDetails {
+  connected: boolean;
+  apiOk?: boolean;
+  apiKeyNotGlobal?: boolean;
+  apiKeyOk?: boolean;
+  websocketBound?: boolean;
+}
+
 export interface PrinterSseMessage {
   printers: Printer[];
   testPrinter: Printer;
+  testProgress: TestProgressDetails;
 }

--- a/client-vue/src/models/sse-messages/printer-sse-message.model.ts
+++ b/client-vue/src/models/sse-messages/printer-sse-message.model.ts
@@ -1,7 +1,6 @@
 import { Printer } from "@/models/printers/printer.model";
 
-// Extensibility options for future use
 export interface PrinterSseMessage {
   printers: Printer[];
-  testPrinters: Printer[];
-};
+  testPrinter: Printer;
+}

--- a/client-vue/src/plugins/veevalidate.ts
+++ b/client-vue/src/plugins/veevalidate.ts
@@ -1,5 +1,5 @@
 import { extend, setInteractionMode } from "vee-validate";
-import { digits, length, max, required } from "vee-validate/dist/rules";
+import { digits, integer, length, max, required } from "vee-validate/dist/rules";
 import validator from "validator";
 
 export function configureVeeValidate() {
@@ -18,6 +18,11 @@ export function configureVeeValidate() {
   extend("length", {
     ...length,
     message: "{_field_} must be of length {length}"
+  });
+
+  extend("integer", {
+    ...integer,
+    message: "{_field_} must be an integer"
   });
 
   extend("ip_or_fqdn", (value) => {

--- a/client-vue/src/store/printers/printers.actions.ts
+++ b/client-vue/src/store/printers/printers.actions.ts
@@ -5,5 +5,6 @@ export const ACTIONS = {
   loadPrinters: "loadPrinters",
   loadPrinterGroups: "loadPrinterGroups",
   loadPrinterFiles: "getPrinterFiles",
-  deletePrinterFile: "deletePrinterFile"
+  deletePrinterFile: "deletePrinterFile",
+  deletePrinter: "deletePrinter"
 };

--- a/client-vue/src/store/printers/printers.actions.ts
+++ b/client-vue/src/store/printers/printers.actions.ts
@@ -1,5 +1,6 @@
 export const ACTIONS = {
   createPrinter: "createPrinter",
+  createTestPrinter: "createTestPrinter",
   savePrinters: "savePrinters",
   loadPrinters: "loadPrinters",
   loadPrinterGroups: "loadPrinterGroups",

--- a/client-vue/src/store/printers/printers.state.ts
+++ b/client-vue/src/store/printers/printers.state.ts
@@ -22,7 +22,8 @@ export const MUTATIONS = {
   savePrinterFiles: "savePrinterFiles",
   deletePrinterFile: "deletePrinterFile",
   savePrinterGroups: "savePrinterGroups",
-  createTestPrinter: "createTestPrinter"
+  createTestPrinter: "createTestPrinter",
+  deletePrinter: "deletePrinter"
 };
 
 export const printersState: StoreOptions<StateInterface> = {
@@ -40,6 +41,15 @@ export const printersState: StoreOptions<StateInterface> = {
     [MUTATIONS.createTestPrinter]: (state, printer: Printer) => {
       state.testPrinters.push(printer);
       state.lastUpdated = Date.now();
+    },
+    [MUTATIONS.deletePrinter]: (state: StateInterface, printerId) => {
+      const printerIndex = state.printers.findIndex((p: Printer) => p.id === printerId);
+
+      if (printerIndex !== -1) {
+        state.printers.splice(printerIndex, 1);
+      } else {
+        console.warn("Printer was not purged as it did not occur in state", printerId);
+      }
     },
     [MUTATIONS.savePrinters]: (state, printers: Printer[]) => {
       state.printers = printers;
@@ -106,6 +116,13 @@ export const printersState: StoreOptions<StateInterface> = {
       const data = await PrintersService.getPrinters();
 
       commit(MUTATIONS.savePrinters, data);
+
+      return data;
+    },
+    [ACTIONS.deletePrinter]: async ({ commit }, printerId) => {
+      const data = await PrintersService.deletePrinter(printerId);
+
+      commit(MUTATIONS.deletePrinter, printerId);
 
       return data;
     },

--- a/client-vue/src/store/printers/printers.state.ts
+++ b/client-vue/src/store/printers/printers.state.ts
@@ -10,6 +10,7 @@ import { PrinterGroupsService } from "@/backend/printer-groups.service";
 
 export interface PrintersStateInterface {
   printers: Printer[];
+  testPrinters: Printer[];
   printerGroups: PrinterGroup[];
   lastUpdated?: number;
 }
@@ -20,12 +21,14 @@ export const MUTATIONS = {
   loadPrinterGroups: "loadPrinterGroups",
   savePrinterFiles: "savePrinterFiles",
   deletePrinterFile: "deletePrinterFile",
-  savePrinterGroups: "savePrinterGroups"
+  savePrinterGroups: "savePrinterGroups",
+  createTestPrinter: "createTestPrinter"
 };
 
 export const printersState: StoreOptions<StateInterface> = {
   state: {
     printers: [],
+    testPrinters: [],
     printerGroups: [],
     lastUpdated: undefined
   },
@@ -33,6 +36,10 @@ export const printersState: StoreOptions<StateInterface> = {
     [MUTATIONS.createPrinter]: (state, printer: Printer) => {
       state.printers.push(printer);
       state.printers.sort((a, b) => (a.sortIndex > b.sortIndex ? 1 : -1));
+    },
+    [MUTATIONS.createTestPrinter]: (state, printer: Printer) => {
+      state.testPrinters.push(printer);
+      state.lastUpdated = Date.now();
     },
     [MUTATIONS.savePrinters]: (state, printers: Printer[]) => {
       state.printers = printers;
@@ -82,6 +89,13 @@ export const printersState: StoreOptions<StateInterface> = {
       commit(MUTATIONS.createPrinter, data);
 
       return newPrinter;
+    },
+    [ACTIONS.createTestPrinter]: async ({ commit }, newPrinter) => {
+      const data = await PrintersService.testConnection(newPrinter);
+
+      commit(MUTATIONS.createTestPrinter, data);
+
+      return data;
     },
     [ACTIONS.savePrinters]: ({ commit }, newPrinters) => {
       commit(MUTATIONS.savePrinters, newPrinters);

--- a/client-vue/src/views/About.vue
+++ b/client-vue/src/views/About.vue
@@ -1,9 +1,11 @@
 <template>
   <v-container>
-    3D Print Farm was created by D. Zwart (https://github.com/davidzwa) in collaboration with <strong><a href="https://mtb3d.com">MTB3D</a></strong> as a spin-off of OctoFarm.
+    3D Print Farm was created by D. Zwart (https://github.com/davidzwa) in collaboration with
+    <strong><a href="https://mtb3d.com">MTB3D</a></strong> as a spin-off of OctoFarm.
 
-    <br/>
-    <br/>
-    Found a bug? Please report them here <strong><a href="https://github.com/davidzwa/3d-print-farm/issues">Github Issues</a></strong>
+    <br />
+    <br />
+    Found a bug? Please report them here
+    <strong><a href="https://github.com/davidzwa/3d-print-farm/issues">Github Issues</a></strong>
   </v-container>
 </template>

--- a/client-vue/src/views/Printers.vue
+++ b/client-vue/src/views/Printers.vue
@@ -66,9 +66,9 @@
         </v-btn>
         <v-badge
           v-if="item.enabled"
+          :color="isPrinterOperational(item) ? 'green' : 'red'"
           bordered
           class="ma-2"
-          :color="isPrinterOperational(item) ? 'green' : 'red'"
           overlap
         >
           <template v-slot:badge>
@@ -111,7 +111,7 @@ import { Printer } from "@/models/printers/printer.model";
 import draggable from "vuedraggable";
 import { PrintersService } from "@/backend/printers.service";
 import { PrinterSseMessage } from "@/models/sse-messages/printer-sse-message.model";
-import { sseMessageEventGlobal } from "@/event-bus/sse.events";
+import { sseMessageGlobal } from "@/event-bus/sse.events";
 import PrinterDetails from "@/components/PrinterDetails.vue";
 
 @Component({
@@ -162,17 +162,18 @@ export default class Printers extends Vue {
   async mounted() {
     await this.loadPrinters();
 
-    this.$bus.on(sseMessageEventGlobal, (data: PrinterSseMessage) => {
+    this.$bus.on(sseMessageGlobal, (data: PrinterSseMessage) => {
       this.onSseMessage(data);
     });
   }
 
-  onSseMessage(printers: PrinterSseMessage) {
-    if (!printers) return;
+  onSseMessage(message: PrinterSseMessage) {
+    if (!message) return;
+    const updatedPrinters = message.printers;
 
     let existingPrinters = this.printers.map((p) => p.id);
 
-    printers.forEach((p) => {
+    updatedPrinters.forEach((p) => {
       const printerIndex = this.printers.findIndex((pr) => pr.id === p.id);
       existingPrinters.splice(printerIndex, 1);
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "3d-print-farm",
       "version": "0.0.1",
       "license": "AGPLv3",
       "dependencies": {

--- a/server/app.constants.js
+++ b/server/app.constants.js
@@ -1,11 +1,4 @@
 class AppConstants {
-  /**
-   * Change the SSE serialization to JSON or flatten
-   */
-  static get jsonStringify() {
-    return true;
-  }
-
   static get apiRoute() {
     return "/api";
   }

--- a/server/container.js
+++ b/server/container.js
@@ -51,6 +51,7 @@ const DashboardStatisticsCache = require("./state/data/dashboard-statistics.cach
 const AlertService = require("./services/alert.service");
 const { asFunction, asClass, asValue, createContainer, InjectionMode } = require("awilix");
 const LoggerFactory = require("./handlers/logger-factory");
+const PrinterTestTask = require("./tasks/printer-test.task");
 
 function configureContainer() {
   // Create the container and set the injectionMode to PROXY (which is also the default).
@@ -64,7 +65,6 @@ function configureContainer() {
     serverVersion: asValue(
       process.env[AppConstants.VERSION_KEY] || AppConstants.defaultServerPageTitle
     ),
-    appConstants: asClass(AppConstants).singleton(),
     serverPageTitle: asValue(process.env[AppConstants.SERVER_SITE_TITLE_KEY]),
 
     // -- asFunction --
@@ -144,11 +144,13 @@ function configureContainer() {
     // Task bound to send on SSE Handler
     [DITokens.printerSseTask]: asClass(PrinterSseTask).singleton(),
     // Normal post-analysis operations (previously called cleaners)
-    printerFilesTask: asClass(PrinterFilesTask).singleton(),
+    [DITokens.printerFilesTask]: asClass(PrinterFilesTask).singleton(),
     // This task is a quick task (~100ms per printer)
-    printerWebsocketTask: asClass(PrinterWebsocketTask).singleton(),
+    [DITokens.printerWebsocketTask]: asClass(PrinterWebsocketTask).singleton(),
     // Task dependent on WS to fire - disabled at boot
-    [DITokens.printerSystemTask]: asClass(PrinterSystemTask).singleton()
+    [DITokens.printerSystemTask]: asClass(PrinterSystemTask).singleton(),
+    // Task dependent on test printer in store - disabled at boot
+    [DITokens.printerTestTask]: asClass(PrinterTestTask).singleton()
   });
 
   return container;

--- a/server/container.tokens.js
+++ b/server/container.tokens.js
@@ -1,4 +1,5 @@
 const DITokens = {
+  loggerFactory: "loggerFactory",
   httpClient: "httpClient",
   printerService: "printerService",
   printerGroupService: "printerGroupService",
@@ -37,11 +38,13 @@ const DITokens = {
   filamentCache: "filamentCache",
   // Tasks
   printerSystemTask: "printerSystemTask",
+  softwareUpdateTask: "softwareUpdateTask",
   printerSseTask: "printerSseTask",
-  dashboardSseTask: "dashboardSseTask",
-  monitoringSseTask: "monitoringSseTask",
+  printerTestTask: "printerTestTask",
   systemCommandsService: "systemCommandsService",
-  loggerFactory: "loggerFactory"
+  printerWebsocketTask: "printerWebsocketTask",
+  printerFilesTask: "printerFilesTask"
+
 };
 
 module.exports = DITokens;

--- a/server/controllers/printer.controller.js
+++ b/server/controllers/printer.controller.js
@@ -13,10 +13,12 @@ const { AppConstants } = require("../app.constants");
 const { convertHttpUrlToWebsocket } = require("../utils/url.utils");
 const { NotImplementedException } = require("../exceptions/runtime.exceptions");
 const { idRules } = require("./validation/generic.validation");
+const DITokens = require("../container.tokens");
 
 class PrinterController {
   #printersStore;
   #jobsCache;
+  #taskManagerService;
   #connectionLogsCache;
   #octoPrintApiService;
   #fileCache;
@@ -29,6 +31,7 @@ class PrinterController {
     printersStore,
     connectionLogsCache,
     printerSseHandler,
+    taskManagerService,
     printerSseTask,
     loggerFactory,
     octoPrintApiService,
@@ -40,6 +43,7 @@ class PrinterController {
     this.#printersStore = printersStore;
     this.#jobsCache = jobsCache;
     this.#connectionLogsCache = connectionLogsCache;
+    this.#taskManagerService = taskManagerService;
     this.#octoPrintApiService = octoPrintApiService;
     this.#fileCache = fileCache;
     this.#sseHandler = printerSseHandler;
@@ -78,6 +82,8 @@ class PrinterController {
 
     // Add printer with test=true
     const printerState = await this.#printersStore.setupTestPrinter(newPrinter);
+
+    this.#taskManagerService.scheduleDisabledJob(DITokens.printerTestTask);
     res.send(printerState.toFlat());
   }
 

--- a/server/controllers/printer.controller.js
+++ b/server/controllers/printer.controller.js
@@ -93,10 +93,13 @@ class PrinterController {
       newPrinter.webSocketURL = convertHttpUrlToWebsocket(newPrinter.printerURL);
     }
 
-    this.#logger.info("Add printer", newPrinter);
-
     // Has internal validation, but might add some here above as well
     const printerState = await this.#printersStore.addPrinter(newPrinter);
+
+    this.#logger.info(
+      `Created printer with ID ${printerState.id || printerState.correlationToken}`
+    );
+
     res.send(printerState.toFlat());
   }
 

--- a/server/controllers/printer.controller.js
+++ b/server/controllers/printer.controller.js
@@ -77,7 +77,7 @@ class PrinterController {
     this.#logger.info("Testing printer", newPrinter);
 
     // Add printer with test=true
-    const printerState = await this.#printersStore.addPrinter(newPrinter, true);
+    const printerState = await this.#printersStore.setupTestPrinter(newPrinter);
     res.send(printerState.toFlat());
   }
 

--- a/server/controllers/printer.controller.js
+++ b/server/controllers/printer.controller.js
@@ -78,7 +78,7 @@ class PrinterController {
 
     // Add printer with test=true
     const printerState = await this.#printersStore.addPrinter(newPrinter, true);
-    res.send({ printerState: printerState.toFlat() });
+    res.send(printerState.toFlat());
   }
 
   async create(req, res) {
@@ -91,7 +91,7 @@ class PrinterController {
 
     // Has internal validation, but might add some here above as well
     const printerState = await this.#printersStore.addPrinter(newPrinter);
-    res.send({ printerState: printerState.toFlat() });
+    res.send(printerState.toFlat());
   }
 
   async list(req, res) {

--- a/server/controllers/printer.controller.js
+++ b/server/controllers/printer.controller.js
@@ -78,7 +78,7 @@ class PrinterController {
     // As we dont generate a _id we generate a correlation token
     newPrinter.correlationToken = Math.random().toString(36).slice(2);
 
-    this.#logger.info("Testing printer", newPrinter);
+    this.#logger.info(`Testing printer with correlation token ${newPrinter.correlationToken}`);
 
     // Add printer with test=true
     const printerState = await this.#printersStore.setupTestPrinter(newPrinter);

--- a/server/controllers/printer.controller.js
+++ b/server/controllers/printer.controller.js
@@ -26,15 +26,15 @@ class PrinterController {
   #logger;
 
   constructor({
-                printersStore,
-                connectionLogsCache,
-                printerSseHandler,
-                printerSseTask,
-                loggerFactory,
-                octoPrintApiService,
-                jobsCache,
-                fileCache
-              }) {
+    printersStore,
+    connectionLogsCache,
+    printerSseHandler,
+    printerSseTask,
+    loggerFactory,
+    octoPrintApiService,
+    jobsCache,
+    fileCache
+  }) {
     this.#logger = loggerFactory("Server-API");
 
     this.#printersStore = printersStore;

--- a/server/handlers/generic-websocket.adapter.js
+++ b/server/handlers/generic-websocket.adapter.js
@@ -15,7 +15,7 @@ module.exports = class GenericWebsocketAdapter {
   // #client;
 
   constructor({ id, webSocketURL /*, currentUser, sessionkey, throttle */ }) {
-    this.#id = id.toString();
+    this.#id = id?.toString();
     this.#webSocketURL = new URL(webSocketURL).href;
 
     // Add your own properties when extending

--- a/server/handlers/logger.js
+++ b/server/handlers/logger.js
@@ -41,7 +41,7 @@ class LoggerService {
         const level = info.level.toUpperCase();
         const date = dateFormat();
         let message = `${date} | ${level} | ${name} | ${info.message}`;
-        message = info.meta ? message + ` data: ${info.meta} | ` : message;
+        message = info.meta ? message + ` - ${JSON.stringify(info.meta)} | ` : message;
         return message;
       })
     });

--- a/server/services/octoprint/constants/octoprint-service.constants.js
+++ b/server/services/octoprint/constants/octoprint-service.constants.js
@@ -14,6 +14,17 @@ const apiKeyHeaderKey = "X-Api-Key";
 const jsonContentType = "application/json";
 const multiPartContentType = "multipart/form-data";
 
+/**
+ * Predicate to check whether login is global type (Global API Key) which would be problematic
+ * @param octoPrintResponse
+ * @returns {boolean}
+ */
+function isLoginResponseGlobal(octoPrintResponse) {
+  // Explicit nullability check serves to let an unconnected printer fall through as well as incorrect apiKey
+  // Note: 'apikey' property is conform OctoPrint response (and not 3DPF printer model's 'apiKey')
+  return !!octoPrintResponse && octoPrintResponse.name === "_api";
+}
+
 // TODO ofc this is lazy - but I'd rather have working code and optimize later
 function getCurrentProfileDefault() {
   return {
@@ -64,6 +75,7 @@ module.exports = {
   apiKeyHeaderKey,
   jsonContentType,
   multiPartContentType,
+  isLoginResponseGlobal,
   getCurrentProfileDefault,
   FileLocation
 };

--- a/server/services/octoprint/octoprint-rxjs-websocket.adapter.js
+++ b/server/services/octoprint/octoprint-rxjs-websocket.adapter.js
@@ -36,7 +36,7 @@ module.exports = class OctoprintRxjsWebsocketAdapter extends GenericWebsocketAda
   #webSocketState = WS_STATE.unopened;
 
   constructor({ id, webSocketURL, currentUser, sessionKey, throttle, debug = false }) {
-    super({ id: id.toString(), webSocketURL });
+    super({ id: id?.toString(), webSocketURL });
 
     this.#currentUser = currentUser;
     this.#sessionKey = sessionKey;

--- a/server/services/printer.service.js
+++ b/server/services/printer.service.js
@@ -21,7 +21,7 @@ class PrinterService {
     });
   }
 
-  async count() {
+  async #printerCount() {
     return Printers.countDocuments();
   }
 
@@ -58,7 +58,7 @@ class PrinterService {
     // We should not to this now: Regenerate sort index on printer add...
     // await this.reGenerateSortIndex();
     mergedPrinter.dateAdded = Date.now();
-    mergedPrinter.sortIndex = await this.count(); // 0-based index so no +1 needed
+    mergedPrinter.sortIndex = await this.#printerCount(); // 0-based index so no +1 needed
 
     await validateInput(mergedPrinter, createPrinterRules);
 

--- a/server/services/task-manager.service.js
+++ b/server/services/task-manager.service.js
@@ -157,6 +157,14 @@ class TaskManagerService {
     this.#scheduleEnabledPeriodicJob(taskID);
   }
 
+  disableJob(taskID) {
+    if (this.isTaskDisabled(taskID)) {
+      throw new JobValidationException("Cant disable a job which is already disabled");
+    }
+
+    this.#getTaskState(taskID).options.disabled = true;
+  }
+
   isTaskDisabled(taskID) {
     return !!this.#getTaskState(taskID).options.disabled;
   }

--- a/server/state/printer-state.factory.js
+++ b/server/state/printer-state.factory.js
@@ -2,11 +2,11 @@ const DITokens = require("../container.tokens");
 
 function PrinterStateFactory(cradle) {
   return {
-    async create(printerDocument) {
+    async create(printerDocument, isTest = false) {
       const printerState = cradle[DITokens.printerState];
 
       // Async just in case setup does async stuff in future
-      await printerState.setup(printerDocument);
+      await printerState.setup(printerDocument, isTest);
 
       return printerState;
     }

--- a/server/state/printer-state.factory.js
+++ b/server/state/printer-state.factory.js
@@ -2,11 +2,11 @@ const DITokens = require("../container.tokens");
 
 function PrinterStateFactory(cradle) {
   return {
-    async create(printerDocument, isTest = false) {
+    async create(printerDocument, isTestPrinter = false) {
       const printerState = cradle[DITokens.printerState];
 
       // Async just in case setup does async stuff in future
-      await printerState.setup(printerDocument, isTest);
+      await printerState.setup(printerDocument, isTestPrinter);
 
       return printerState;
     }

--- a/server/state/printer.state.js
+++ b/server/state/printer.state.js
@@ -23,6 +23,7 @@ const Logger = require("../handlers/logger.js");
  */
 class PrinterState {
   #id;
+  #isTest;
 
   #hostState = {
     state: PSTATE.Offline,
@@ -74,12 +75,18 @@ class PrinterState {
     return this.#id;
   }
 
+  get isTest() {
+    return this.#isTest;
+  }
+
   get markForRemoval() {
     return this.#markedForRemoval;
   }
 
-  async setup(printerDocument) {
-    this.#id = printerDocument._id.toString();
+  async setup(printerDocument, isTest = false) {
+    if (!isTest) this.#id = printerDocument._id.toString();
+    this.#isTest = isTest;
+
     this.updateEntityData(printerDocument, true);
   }
 
@@ -149,7 +156,10 @@ class PrinterState {
     // );
 
     flatJob = JobsCache.postProcessJob(flatJob, costSettings);
-    const fileList = this.#fileCache.getPrinterFiles(this.#id);
+    let fileList = [];
+    if (!this.isTest) {
+      fileList = this.#fileCache.getPrinterFiles(this.#id);
+    }
 
     // TODO call files store for thumb
     // const foundFile = _.find(printerState.getFileList().files, (o) => {
@@ -159,8 +169,12 @@ class PrinterState {
     //   currentJob.thumbnail = foundFile.thumbnail;
     // }
 
+    const identification = this.isTest
+      ? { correlationToken: this.#entityData.correlationToken, isTest: this.isTest }
+      : { id: this.#id };
+
     return Object.freeze({
-      id: this.#id,
+      ...identification,
       printerState: this.getPrinterState(),
       hostState: this.#hostState,
       webSocketState: convertedWSState,

--- a/server/state/printer.state.js
+++ b/server/state/printer.state.js
@@ -93,6 +93,9 @@ class PrinterState {
   async tearDown() {
     this.resetWebSocketAdapter();
     this.#markedForRemoval = true;
+
+    if (this.isTest) return;
+
     this.#fileCache.purgePrinterId(this.#id);
     this.#jobsCache.purgePrinterId(this.#id);
   }

--- a/server/state/printer.state.js
+++ b/server/state/printer.state.js
@@ -79,6 +79,10 @@ class PrinterState {
     return this.#isTest;
   }
 
+  get correlationToken() {
+    if (this.isTest) return this.#entityData.correlationToken;
+  }
+
   get markForRemoval() {
     return this.#markedForRemoval;
   }

--- a/server/state/printers.store.js
+++ b/server/state/printers.store.js
@@ -95,7 +95,7 @@ class PrintersStore {
     this._validateState();
 
     return this.#printerStates.filter(
-      (p) => !isTest ? (includeDisconnected || p.markForRemoval === false) : !!p.isTest
+      (p) => !isTest ? (includeDisconnected || p.markForRemoval === false) && !p.isTest : p.isTest
     );
   }
 

--- a/server/state/printers.store.js
+++ b/server/state/printers.store.js
@@ -19,12 +19,12 @@ class PrintersStore {
   #logger = new Logger("Server-PrintersStore");
 
   constructor({
-                settingsStore,
-                printerTickerStore,
-                printerStateFactory,
-                eventEmitter2,
-                printerService
-              }) {
+    settingsStore,
+    printerTickerStore,
+    printerStateFactory,
+    eventEmitter2,
+    printerService
+  }) {
     this.#settingsStore = settingsStore;
     this.#printerService = printerService;
     this.#printerTickerStore = printerTickerStore;
@@ -277,7 +277,7 @@ class PrintersStore {
 
     const newPrinterDoc = { _doc: validatedData };
     this.#logger.info(
-      `Stored test Printer: ${newPrinterDoc.printerURL} with ID ${newPrinterDoc.correlationToken}`
+      `Stored test Printer: ${validatedData.printerURL} with ID ${validatedData.correlationToken}`
     );
 
     const newPrinterState = await this.#printerStateFactory.create(newPrinterDoc, true);

--- a/server/state/printers.store.js
+++ b/server/state/printers.store.js
@@ -253,7 +253,7 @@ class PrintersStore {
       `Saved new Printer: ${newPrinterDoc.printerURL} with ID ${newPrinterDoc._id}`
     );
 
-    const newPrinterState = await this.#printerStateFactory.create(newPrinterDoc, isTest);
+    const newPrinterState = await this.#printerStateFactory.create(newPrinterDoc);
     this.#printerStates.push(newPrinterState);
 
     // The next 'round' will involve setting up a websocket for this printer

--- a/server/state/printers.store.js
+++ b/server/state/printers.store.js
@@ -18,12 +18,12 @@ class PrintersStore {
   #logger = new Logger("Server-PrintersStore");
 
   constructor({
-                settingsStore,
-                printerTickerStore,
-                printerStateFactory,
-                eventEmitter2,
-                printerService
-              }) {
+    settingsStore,
+    printerTickerStore,
+    printerStateFactory,
+    eventEmitter2,
+    printerService
+  }) {
     this.#settingsStore = settingsStore;
     this.#printerService = printerService;
     this.#printerTickerStore = printerTickerStore;
@@ -75,10 +75,11 @@ class PrintersStore {
 
   /**
    * Return a mutable copy of all frozen printers states mapped to flat JSON
-   * @param {boolean} filterDisconnected printers marked by tearDown (disconnected) are be filtered
+   * @param {boolean} includeDisconnected printers marked by tearDown (disconnected) are be filtered
+   * @param isTest
    */
-  listPrintersFlat(filterDisconnected = true) {
-    return this.listPrinterStates(filterDisconnected)
+  listPrintersFlat(isTest = false, includeDisconnected = false) {
+    return this.listPrinterStates(isTest, includeDisconnected)
       .filter((s) => s.toFlat)
       .map((s) => s.toFlat());
   }
@@ -87,12 +88,15 @@ class PrintersStore {
    * List the prefetched printer states without mapping
    * We check and throw instead of loading proactively: more predictable and not async
    * @returns {*}
-   * @param {boolean} filterDisconnected printers marked by tearDown (disconnected) are be filtered
+   * @param includeDisconnected
+   * @param isTest takes complete preference over 'includeDisconnected'
    */
-  listPrinterStates(filterDisconnected = true) {
+  listPrinterStates(isTest = false, includeDisconnected = false) {
     this._validateState();
 
-    return this.#printerStates.filter((p) => (filterDisconnected || p.markForRemoval === false) && !p.isTest);
+    return this.#printerStates.filter(
+      (p) => !isTest ? (includeDisconnected || p.markForRemoval === false) : !!p.isTest
+    );
   }
 
   getPrinterCount() {

--- a/server/state/printers.store.js
+++ b/server/state/printers.store.js
@@ -85,8 +85,8 @@ class PrintersStore {
       .map((s) => s.toFlat());
   }
 
-  getTestPrinterFlat() {
-    return this.#testPrinterState?.toFlat();
+  getTestPrinter() {
+    return this.#testPrinterState;
   }
 
   /**
@@ -163,6 +163,12 @@ class PrintersStore {
 
     this.#logger.info(`Loaded ${this.#printerStates.length} printer states`);
     this.generatePrinterGroups();
+  }
+
+  async deleteTestPrinter() {
+    await this.#testPrinterState.tearDown();
+
+    this.#testPrinterState = undefined;
   }
 
   async deletePrinter(printerId) {
@@ -276,7 +282,7 @@ class PrintersStore {
 
     const newPrinterState = await this.#printerStateFactory.create(newPrinterDoc, true);
     if (this.#testPrinterState) {
-      await this.#testPrinterState.tearDown();
+      await this.deleteTestPrinter();
     }
 
     this.#testPrinterState = newPrinterState;

--- a/server/state/validation/create-test-printer.validation.js
+++ b/server/state/validation/create-test-printer.validation.js
@@ -1,0 +1,13 @@
+const { UUID_LENGTH } = require("../../constants/service.constants");
+
+const createTestPrinterRules = {
+  apiKey: `required|length:${UUID_LENGTH},${UUID_LENGTH}|alphaNumeric`,
+  correlationToken: "required|string",
+  printerURL: "required|httpurl",
+  webSocketURL: "required|wsurl",
+  camURL: "httpurl"
+};
+
+module.exports = {
+  createTestPrinterRules
+};

--- a/server/tasks.js
+++ b/server/tasks.js
@@ -25,7 +25,7 @@ class ServerTasks {
   static BOOT_TASKS = [
     registerTask(DITokens.softwareUpdateTask, TaskPresets.RUNDELAYED, 1500),
     registerTask(DITokens.printerSseTask, TaskPresets.PERIODIC, 500),
-    registerTask(DITokens.printerTestTask, TaskPresets.PERIODIC_DISABLED, 2000),
+    registerTask(DITokens.printerTestTask, TaskPresets.PERIODIC_DISABLED, 2000, true),
     registerTask(DITokens.printerSystemTask, TaskPresets.PERIODIC_DISABLED, 6 * HOUR_MS, true),
     registerTask(DITokens.printerWebsocketTask, TaskPresets.PERIODIC, 5000, true),
     registerTask(DITokens.printerFilesTask, TaskPresets.RUNONCE, 15000) // We dont need more than this

--- a/server/tasks.js
+++ b/server/tasks.js
@@ -1,4 +1,5 @@
 const { TaskPresets } = require("./task.presets");
+const DITokens = require("./container.tokens");
 
 /**
  * Register a task with a preset and timing (run immediate does not retry in case of failure)
@@ -22,11 +23,12 @@ const HOUR_MS = 3600 * 1000;
 
 class ServerTasks {
   static BOOT_TASKS = [
-    registerTask("softwareUpdateTask", TaskPresets.RUNDELAYED, 1500),
-    registerTask("printerSseTask", TaskPresets.PERIODIC, 500),
-    registerTask("printerSystemTask", TaskPresets.PERIODIC_DISABLED, 6 * HOUR_MS, true),
-    registerTask("printerWebsocketTask", TaskPresets.PERIODIC, 5000, true),
-    registerTask("printerFilesTask", TaskPresets.RUNONCE, 15000) // We dont need more than this
+    registerTask(DITokens.softwareUpdateTask, TaskPresets.RUNDELAYED, 1500),
+    registerTask(DITokens.printerSseTask, TaskPresets.PERIODIC, 500),
+    registerTask(DITokens.printerTestTask, TaskPresets.PERIODIC_DISABLED, 2000),
+    registerTask(DITokens.printerSystemTask, TaskPresets.PERIODIC_DISABLED, 6 * HOUR_MS, true),
+    registerTask(DITokens.printerWebsocketTask, TaskPresets.PERIODIC, 5000, true),
+    registerTask(DITokens.printerFilesTask, TaskPresets.RUNONCE, 15000) // We dont need more than this
   ];
 }
 

--- a/server/tasks/printer-sse.task.js
+++ b/server/tasks/printer-sse.task.js
@@ -19,7 +19,12 @@ class PrinterSseTask {
   }
 
   async run() {
-    const sseData = this.#printersStore.listPrintersFlat();
+    const printerStates = this.#printersStore.listPrintersFlat();
+    const testPrinterStates = this.#printersStore.listPrintersFlat(true);
+    const sseData = {
+      printers: printerStates,
+      testPrinters: testPrinterStates
+    };
 
     const serializedData = AppConstants.jsonStringify
       ? JSON.stringify(sseData)

--- a/server/tasks/printer-sse.task.js
+++ b/server/tasks/printer-sse.task.js
@@ -1,5 +1,4 @@
 const { stringify } = require("flatted");
-const Logger = require("../handlers/logger");
 const { AppConstants } = require("../app.constants");
 const { byteCount } = require("../utils/benchmark.util");
 
@@ -11,19 +10,20 @@ class PrinterSseTask {
   #aggregateWindowLength = 100;
   #aggregateSizes = [];
   #rounding = 2;
-  #logger = new Logger("Printer-SSE-task");
+  #logger;
 
-  constructor({ printerSseHandler, printersStore }) {
+  constructor({ printerSseHandler, printersStore, loggerFactory }) {
     this.#printerSseHandler = printerSseHandler;
     this.#printersStore = printersStore;
+    this.#logger = loggerFactory("Printer-SSE-task");
   }
 
   async run() {
     const printerStates = this.#printersStore.listPrintersFlat();
-    const testPrinterStates = this.#printersStore.listPrintersFlat(true);
+    const testPrinterState = this.#printersStore.getTestPrinterFlat();
     const sseData = {
       printers: printerStates,
-      testPrinters: testPrinterStates
+      testPrinter: testPrinterState
     };
 
     const serializedData = AppConstants.jsonStringify

--- a/server/tasks/printer-sse.task.js
+++ b/server/tasks/printer-sse.task.js
@@ -1,5 +1,3 @@
-const { stringify } = require("flatted");
-const { AppConstants } = require("../app.constants");
 const { byteCount } = require("../utils/benchmark.util");
 
 class PrinterSseTask {
@@ -20,15 +18,12 @@ class PrinterSseTask {
 
   async run() {
     const printerStates = this.#printersStore.listPrintersFlat();
-    const testPrinterState = this.#printersStore.getTestPrinterFlat();
+
     const sseData = {
       printers: printerStates,
-      testPrinter: testPrinterState
     };
 
-    const serializedData = AppConstants.jsonStringify
-      ? JSON.stringify(sseData)
-      : stringify(sseData);
+    const serializedData = JSON.stringify(sseData);
     const transportDataSize = byteCount(serializedData);
     this.updateAggregator(transportDataSize);
     this.#printerSseHandler.send(serializedData);

--- a/server/tasks/printer-test.task.js
+++ b/server/tasks/printer-test.task.js
@@ -114,7 +114,7 @@ class PrinterTestTask {
 
       return await this.#sendStateProgress(printerState, { connected: false });
     }
-    return await this.#sendStateProgress(printerState, { connected: true });
+    await this.#sendStateProgress(printerState, { connected: true });
 
     // API related errors
     if (errorCode === HttpStatusCode.BAD_REQUEST) {

--- a/server/tasks/printer-test.task.js
+++ b/server/tasks/printer-test.task.js
@@ -44,8 +44,8 @@ class PrinterTestTask {
       : false;
 
     if (!testPrinterState?.toFlat || taskExpired) {
-      this.#lastTestRunTime = undefined;
-      this.#logger.info("Printer test task has completed and is disabled.");
+      this.#stopRunning();
+
       if (testPrinterState?.toFlat) {
         await this.#printersStore.deleteTestPrinter();
       }
@@ -55,6 +55,13 @@ class PrinterTestTask {
     }
 
     await this.#testPrinterConnection(testPrinterState);
+    this.#stopRunning();
+  }
+
+  #stopRunning() {
+    this.#lastTestRunTime = undefined;
+    this.#taskManagerService.disableJob(DITokens.printerTestTask);
+    this.#logger.info("Printer test task has stopped running and is disabled.");
   }
 
   /**

--- a/server/tasks/printer-test.task.js
+++ b/server/tasks/printer-test.task.js
@@ -63,16 +63,26 @@ class PrinterTestTask {
    * @returns {Promise<void>}
    */
   async #sendStateProgress(testPrinterState, progress) {
-    const { correlationToken, hostState, printerState, webSocketState } =
-      testPrinterState?.toFlat();
+    const {
+      printerURL,
+      printerName,
+      apiKey,
+      correlationToken,
+      hostState,
+      printerState,
+      webSocketState
+    } = testPrinterState?.toFlat();
     const sseData = {
       testPrinter: {
+        printerURL,
+        printerName,
+        apiKey,
         correlationToken,
         hostState,
         printerState,
-        webSocketState
-      },
-      progress
+        webSocketState,
+        progress
+      }
     };
 
     const serializedData = JSON.stringify(sseData);

--- a/server/tasks/printer-test.task.js
+++ b/server/tasks/printer-test.task.js
@@ -44,7 +44,8 @@ class PrinterTestTask {
       : false;
 
     if (!testPrinterState?.toFlat || taskExpired) {
-      this.#logger.info("Printer test task has expired or testPrinterState was not created.");
+      this.#lastTestRunTime = undefined;
+      this.#logger.info("Printer test task has completed and is disabled.");
       if (testPrinterState?.toFlat) {
         await this.#printersStore.deleteTestPrinter();
       }
@@ -103,7 +104,7 @@ class PrinterTestTask {
 
     // API related errors
     if (errorCode === HttpStatusCode.BAD_REQUEST) {
-      return await this.#sendStateProgress(printerState, { connected: true, api_ok: false });
+      return await this.#sendStateProgress(printerState, { connected: true, apiOk: false });
     }
     await this.#sendStateProgress(printerState, { connected: true, apiOk: true });
 

--- a/server/tasks/printer-test.task.js
+++ b/server/tasks/printer-test.task.js
@@ -1,0 +1,142 @@
+const { byteCount } = require("../utils/benchmark.util");
+const { PSTATE, MESSAGE } = require("../constants/state.constants");
+const HttpStatusCode = require("../constants/http-status-codes.constants");
+const OctoprintRxjsWebsocketAdapter = require("../services/octoprint/octoprint-rxjs-websocket.adapter");
+const {
+  isLoginResponseGlobal
+} = require("../services/octoprint/constants/octoprint-service.constants");
+const DITokens = require("../container.tokens");
+
+class PrinterTestTask {
+  #lastTestRunTime;
+  #printerSseHandler;
+
+  #printersStore;
+  #settingsStore;
+  #octoPrintService;
+  #taskManagerService;
+
+  #logger;
+
+  constructor({
+    printersStore,
+    octoPrintApiService,
+    settingsStore,
+    taskManagerService,
+    loggerFactory,
+    printerSseHandler
+  }) {
+    this.#printersStore = printersStore;
+    this.#settingsStore = settingsStore;
+    this.#octoPrintService = octoPrintApiService;
+    this.#taskManagerService = taskManagerService;
+    this.#printerSseHandler = printerSseHandler;
+    this.#logger = loggerFactory("Printer-Test-task");
+  }
+
+  get maxRunTime() {
+    return 10000; // 10 sec
+  }
+
+  async run() {
+    const testPrinterState = this.#printersStore.getTestPrinter();
+    const taskExpired = this.#lastTestRunTime
+      ? Date.now() > this.#lastTestRunTime + this.maxRunTime
+      : false;
+
+    if (!testPrinterState?.toFlat || taskExpired) {
+      this.#logger.info("Printer test task has expired or testPrinterState was not created.");
+      if (testPrinterState?.toFlat) {
+        await this.#printersStore.deleteTestPrinter();
+      }
+
+      this.#taskManagerService.disableJob(DITokens.printerTestTask);
+      return;
+    }
+
+    await this.#testPrinterConnection(testPrinterState);
+  }
+
+  /**
+   * Update the UI with test status
+   * @param testPrinterState
+   * @returns {Promise<void>}
+   */
+  async #sendStateProgress(testPrinterState) {
+    const sseData = {
+      testPrinter: testPrinterState?.toFlat()
+    };
+    const serializedData = JSON.stringify(sseData);
+    const transportDataSize = byteCount(serializedData);
+
+    this.#printerSseHandler.send(serializedData);
+  }
+
+  async #testPrinterConnection(printerState) {
+    this.#lastTestRunTime = Date.now();
+    const loginDetails = printerState.getLoginDetails();
+
+    if (!printerState.shouldRetryConnect()) {
+      return;
+    }
+
+    let errorThrown = false;
+    let localError;
+
+    const response = await this.#octoPrintService.login(loginDetails, true).catch((e) => {
+      errorThrown = true;
+      localError = e;
+    });
+
+    // Transport related error
+    let errorCode = localError?.response?.status;
+    if (errorThrown && !localError.response) {
+      // Not connected or DNS issue - abort flow
+      printerState.setHostState(PSTATE.Offline, MESSAGE.offline);
+      printerState.setApiAccessibility(false, true, MESSAGE.retryingApiConnection);
+
+      return;
+    }
+
+    // API related errors
+    if (errorCode === HttpStatusCode.BAD_REQUEST) {
+      // Bug
+      printerState.setHostState(PSTATE.NoAPI, MESSAGE.badRequest);
+      printerState.setApiAccessibility(false, false, MESSAGE.badRequest);
+      return;
+    }
+
+    // Response related errors
+    const loginResponse = response.data;
+    // This is a check which is best done after checking 400 code (GlobalAPIKey or pass-thru) - possible
+    if (isLoginResponseGlobal(loginResponse)) {
+      printerState.setHostState(PSTATE.GlobalAPIKey, MESSAGE.globalAPIKeyDetected);
+      printerState.setApiAccessibility(false, false, MESSAGE.globalAPIKeyDetected);
+      return;
+    }
+
+    // Check for an name (defines connection state NoAPI) - undefined when apikey is wrong
+    if (!loginResponse?.name) {
+      printerState.setHostState(PSTATE.ApiKeyRejected, MESSAGE.apiKeyNotAccepted);
+      printerState.setApiAccessibility(false, false, MESSAGE.apiKeyNotAccepted);
+      return;
+    }
+
+    // Sanity check for login success (alt: could also check status code) - quite rare
+    if (!loginResponse?.session) {
+      printerState.setHostState(PSTATE.NoAPI, MESSAGE.missingSessionKey);
+      printerState.setApiAccessibility(false, false, MESSAGE.missingSessionKey);
+      return;
+    }
+
+    printerState.setApiLoginSuccessState(loginResponse.name, loginResponse?.session);
+    printerState.setApiAccessibility(true, true, null);
+    printerState.resetWebSocketAdapter();
+    printerState.bindWebSocketAdapter(OctoprintRxjsWebsocketAdapter);
+
+    // Delaying or staggering this will speed up startup tasks - ~90 to 150ms per printer on non-congested (W)LAN
+    printerState.connectAdapter();
+  }
+}
+
+module.exports = PrinterTestTask;

--- a/test/api/printers.test.js
+++ b/test/api/printers.test.js
@@ -46,9 +46,7 @@ describe("PrintersController", () => {
       tempTriggers: { heatingVariation: null }
     });
     expectOkResponse(response, {
-      printerState: {
-        printerURL: expect.any(String)
-      }
+      printerURL: expect.any(String)
     });
   });
 
@@ -70,9 +68,9 @@ describe("PrintersController", () => {
       apiKey: "3dpf3dpf3dpf3dpf3dpf3dpf3dpf3dpf",
       tempTriggers: { heatingVariation: null }
     });
-    const body = expectOkResponse(createResponse, { printerState: expect.anything() });
+    const body = expectOkResponse(createResponse, expect.anything());
 
-    const deletionResponse = await request.delete(`${deleteRoute}/${body.printerState.id}`).send();
+    const deletionResponse = await request.delete(`${deleteRoute}/${body.id}`).send();
     expectOkResponse(deletionResponse, expect.anything());
   });
 

--- a/test/api/sse-printers.test.js
+++ b/test/api/sse-printers.test.js
@@ -1,13 +1,11 @@
 jest.mock("../../server/middleware/auth");
 
 const EventSource = require("eventsource");
-const { parse } = require("flatted/cjs");
 const dbHandler = require("../db-handler");
 const supertest = require("supertest");
 const getEndpoints = require("express-list-endpoints");
 const { setupTestApp } = require("../../server/app-test");
 const DITokens = require("../../server/container.tokens");
-const { AppConstants } = require("../../server/app.constants");
 
 let request;
 let sseTask;
@@ -43,12 +41,7 @@ describe("SSE-printers", () => {
       es.onmessage = (e) => {
         firedEvent = true;
 
-        let parsedMsg;
-        if (AppConstants.jsonStringify) {
-          parsedMsg = JSON.parse(e.data);
-        } else {
-          parsedMsg = parse(e.data);
-        }
+        let parsedMsg = JSON.parse(e.data);
         expect(parsedMsg).toEqual({ printers: [] });
         es.close();
         resolve();

--- a/test/api/sse-printers.test.js
+++ b/test/api/sse-printers.test.js
@@ -49,7 +49,7 @@ describe("SSE-printers", () => {
         } else {
           parsedMsg = parse(e.data);
         }
-        expect(parsedMsg).toEqual([]);
+        expect(parsedMsg).toEqual({ printers: [] });
         es.close();
         resolve();
       };


### PR DESCRIPTION
- [x] Ability to test a printer before submission with SSE feedback mechanism
- [x] Auto-cleanup and disable periodic scheduling test printer task
- [x] Add panel with checkmarks to show printer connection verification
- [x] Fixed a bug in SSE event-bus message (printers object was nested)
- [x] Add delete printer to frontend

Has some leftover issues like confirmation of printer creation, accepting a http URL (smart form feature), loading groups from API and printerName is not stored nor auto-queried from OctoPrint.